### PR TITLE
CLI: bypass password confirmation when terminal password is from a chain

### DIFF
--- a/cli/cli.h
+++ b/cli/cli.h
@@ -8,6 +8,7 @@
 typedef struct {
   char *main;
   size_t main_len;
+  bool confirmed; ///< should any password confirmation prompts be bypassed?
 } main_t;
 
 main_t *getpassword(const char *prompt);

--- a/cli/main.c
+++ b/cli/main.c
@@ -17,6 +17,7 @@
 #include <passwand/passwand.h>
 #include <pthread.h>
 #include <stdatomic.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -158,6 +159,7 @@ main_t *getpassword(const char *prompt) {
   }
   mainpass->main = m;
   mainpass->main_len = size;
+  mainpass->confirmed = false;
 
   return mainpass;
 }
@@ -264,6 +266,10 @@ static void process_chain_link(void *state,
     assert(m->main != NULL);
     strcpy(m->main, value);
     m->main_len = strlen(value) + 1;
+
+    // this password is coming from a database field, so we can assume it is not
+    // typoed
+    m->confirmed = true;
   }
 }
 

--- a/cli/set.c
+++ b/cli/set.c
@@ -25,16 +25,18 @@ int set_initialize(const main_t *mainpass, passwand_entry_t *entries,
   saved_entry_len = entry_len;
   found = false;
 
-  main_t *confirm = getpassword("confirm main password: ");
-  if (confirm == NULL) {
-    eprint("out of memory\n");
-    return -1;
-  }
-  bool r = strcmp(mainpass->main, confirm->main) == 0;
-  discard_main(confirm);
-  if (!r) {
-    eprint("passwords do not match\n");
-    return -1;
+  if (!mainpass->confirmed) {
+    main_t *confirm = getpassword("confirm main password: ");
+    if (confirm == NULL) {
+      eprint("out of memory\n");
+      return -1;
+    }
+    bool r = strcmp(mainpass->main, confirm->main) == 0;
+    discard_main(confirm);
+    if (!r) {
+      eprint("passwords do not match\n");
+      return -1;
+    }
   }
 
   return 0;

--- a/cli/update.c
+++ b/cli/update.c
@@ -27,16 +27,18 @@ static int initialize(const main_t *mainpass, passwand_entry_t *entries,
   found = false;
   found_index = 0;
 
-  main_t *confirm = getpassword("confirm main password: ");
-  if (confirm == NULL) {
-    eprint("out of memory\n");
-    return -1;
-  }
-  bool r = strcmp(mainpass->main, confirm->main) == 0;
-  discard_main(confirm);
-  if (!r) {
-    eprint("passwords do not match\n");
-    return -1;
+  if (!mainpass->confirmed) {
+    main_t *confirm = getpassword("confirm main password: ");
+    if (confirm == NULL) {
+      eprint("out of memory\n");
+      return -1;
+    }
+    bool r = strcmp(mainpass->main, confirm->main) == 0;
+    discard_main(confirm);
+    if (!r) {
+      eprint("passwords do not match\n");
+      return -1;
+    }
   }
 
   return 0;

--- a/tests/integration-tests.py
+++ b/tests/integration-tests.py
@@ -1728,8 +1728,6 @@ class Cli(PasswandTest):
             'foo', '--key', 'bar']
     p = pexpect.spawn('./pw-cli', args, timeout=120)
     self.type_password(p, 'chain password')
-    p.expect('confirm main password: ')
-    p.sendline('main password') # FIXME
     p.expect(pexpect.EOF)
     p.close()
     self.assertEqual(p.exitstatus, 0)
@@ -1797,8 +1795,6 @@ class Cli(PasswandTest):
             '--key', 'bar', '--value', 'value']
     p = pexpect.spawn('./pw-cli', args, timeout=120)
     self.type_password(p, 'chain password')
-    p.expect('confirm main password: ')
-    p.sendline('main password') # FIXME
     p.expect(pexpect.EOF)
     p.close()
     self.assertNotEqual(p.exitstatus, 0)
@@ -1812,8 +1808,6 @@ class Cli(PasswandTest):
             '--key', 'qux', '--value', 'corge']
     p = pexpect.spawn('./pw-cli', args, timeout=120)
     self.type_password(p, 'chain password')
-    p.expect('confirm main password: ')
-    p.sendline('main password') # FIXME
     p.expect(pexpect.EOF)
     p.close()
     self.assertEqual(p.exitstatus, 0)
@@ -1842,8 +1836,6 @@ class Cli(PasswandTest):
             'foo', '--key', 'baz', '--value', 'value']
     p = pexpect.spawn('./pw-cli', args, timeout=120)
     self.type_password(p, 'chain password')
-    p.expect('confirm main password: ')
-    p.sendline('main password') # FIXME
     p.expect(pexpect.EOF)
     p.close()
     self.assertNotEqual(p.exitstatus, 0)
@@ -1857,8 +1849,6 @@ class Cli(PasswandTest):
             'foo', '--key', 'bar', '--value', 'corge']
     p = pexpect.spawn('./pw-cli', args, timeout=120)
     self.type_password(p, 'chain password')
-    p.expect('confirm main password: ')
-    p.sendline('main password') # FIXME
     p.expect(pexpect.EOF)
     p.close()
     self.assertEqual(p.exitstatus, 0)


### PR DESCRIPTION
This addresses point 1 from 11a0474cfb9b07cbea67daefccb3cd172fc4e071.

Commands that set an entry (`generate`, `set`, and `update`) ask for
confirmation of the password to ensure the user did not typo it. When using a
database chain, this had the unfortunate UI effect of asking for confirmation
but requiring the _terminal_ password instead of an earlier chained password.
Apart from being confusing, this confirmation is unnecessary. If the terminal
password originates from an entry in a chained database, we can be reasonably
sure it was not typoed.

This change makes these commands skip password confirmation in this scenario.