### PR TITLE
cli: support database chaining with empty string passwords

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -383,7 +383,6 @@ int main(int argc, char **argv) {
     // extract the password from this database to use as the new main password
     assert(mainpass != NULL);
     assert(mainpass->main != NULL);
-    assert(strcmp(mainpass->main, "") != 0);
     passwand_error_t err =
         passwand_entry_do(mainpass->main, &entries[0], process_chain_link, mainpass);
 


### PR DESCRIPTION
This addresses point 2 from 11a0474cfb9b07cbea67daefccb3cd172fc4e071.

As of this commit, database chaining is fully supported in the CLI.