### PR TITLE
gui: fix: use XTest to type characters under X11

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ task:
         # $LC_ALL to make `man` work correctly
         LC_ALL: C
         UBSAN_OPTIONS: print_stacktrace=1
-      install_script: apt-get update -y && apt-get install --no-install-recommends -y cmake libcunit1-dev libgtk2.0-dev libjson-c-dev libscrypt-kdf1 libscrypt-kdf-dev man-db python3-pexpect xxd
+      install_script: apt-get update -y && apt-get install --no-install-recommends -y cmake libcunit1-dev libgtk2.0-dev libjson-c-dev libscrypt-kdf1 libscrypt-kdf-dev libxtst-dev man-db python3-pexpect xxd
       test_script: uname -sr && python3 --version && mkdir build && cd build && cmake .. && cmake --build . -- pw-cli pw-gui-test-stub pw-gui passwand-tests test-type && cmake --build . -- check && cmake --build . -- install
 
     - name: Linux, GCC, GTK 3
@@ -46,7 +46,7 @@ task:
         # $LC_ALL to make `man` work correctly
         LC_ALL: C
         UBSAN_OPTIONS: print_stacktrace=1
-      install_script: apt-get update -y && apt-get install --no-install-recommends -y cmake libcunit1-dev libgtk-3-dev libjson-c-dev libscrypt-kdf1 libscrypt-kdf-dev man-db python3-pexpect xxd
+      install_script: apt-get update -y && apt-get install --no-install-recommends -y cmake libcunit1-dev libgtk-3-dev libjson-c-dev libscrypt-kdf1 libscrypt-kdf-dev libxtst-dev man-db python3-pexpect xxd
       test_script: uname -sr && python3 --version && mkdir build && cd build && cmake .. && cmake --build . -- pw-cli pw-gui-test-stub pw-gui passwand-tests test-type && cmake --build . -- check && cmake --build . -- install
 
     - name: macOS

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -29,6 +29,7 @@ if(ENABLE_GUI)
       set(INPUT_C wayland.c)
     else()
       pkg_check_modules(X11 REQUIRED x11)
+      pkg_check_modules(XTST REQUIRED xtst)
       set(INPUT_C x11.c)
     endif()
   elseif(OSASCRIPT)
@@ -57,8 +58,11 @@ if(ENABLE_GUI)
 
   if(GTK3_FOUND OR GTK2_FOUND)
     if(NOT USE_WAYLAND)
-      target_include_directories(pw-gui SYSTEM PRIVATE ${X11_INCLUDE_DIRS})
-      target_link_libraries(pw-gui PRIVATE ${X11_LIBRARIES})
+      target_include_directories(pw-gui SYSTEM PRIVATE
+        ${X11_INCLUDE_DIRS}
+        ${XTST_INCLUDE_DIRS}
+      )
+      target_link_libraries(pw-gui PRIVATE ${X11_LIBRARIES} ${XTST_LIBRARIES})
     endif()
   endif()
 
@@ -83,8 +87,14 @@ if(ENABLE_GUI)
 
   if(GTK3_FOUND OR GTK2_FOUND)
     if(NOT USE_WAYLAND)
-      target_include_directories(test-type SYSTEM PRIVATE ${X11_INCLUDE_DIRS})
-      target_link_libraries(test-type PRIVATE ${X11_LIBRARIES})
+      target_include_directories(test-type SYSTEM PRIVATE
+        ${X11_INCLUDE_DIRS}
+        ${XTST_INCLUDE_DIRS}
+      )
+      target_link_libraries(test-type PRIVATE
+        ${X11_LIBRARIES}
+        ${XTST_LIBRARIES}
+      )
     endif()
   endif()
 

--- a/gui/x11.c
+++ b/gui/x11.c
@@ -37,8 +37,10 @@ int send_text(const char *text) {
 
   assert(text != NULL);
 
-  int err __attribute__((unused)) = pthread_mutex_lock(&gtk_lock);
-  assert(err == 0);
+  {
+    int err __attribute__((unused)) = pthread_mutex_lock(&gtk_lock);
+    assert(err == 0);
+  }
 
   // find the current display
   const char *display = getenv_("DISPLAY");
@@ -46,8 +48,10 @@ int send_text(const char *text) {
     display = ":0";
   Display *d = XOpenDisplay(display);
   if (d == NULL) {
-    err = pthread_mutex_unlock(&gtk_lock);
-    assert(err == 0);
+    {
+      int err __attribute__((unused)) = pthread_mutex_unlock(&gtk_lock);
+      assert(err == 0);
+    }
     show_error("failed to open X11 display");
     return -1;
   }
@@ -58,8 +62,10 @@ int send_text(const char *text) {
   XGetInputFocus(d, &win, &state);
   if (win == None) {
     XCloseDisplay(d);
-    err = pthread_mutex_unlock(&gtk_lock);
-    assert(err == 0);
+    {
+      int err __attribute__((unused)) = pthread_mutex_unlock(&gtk_lock);
+      assert(err == 0);
+    }
     show_error("no window focused");
     return -1;
   }
@@ -71,8 +77,10 @@ int send_text(const char *text) {
 
   XCloseDisplay(d);
 
-  err = pthread_mutex_unlock(&gtk_lock);
-  assert(err == 0);
+  {
+    int err __attribute__((unused)) = pthread_mutex_unlock(&gtk_lock);
+    assert(err == 0);
+  }
 
   return 0;
 }

--- a/gui/x11.c
+++ b/gui/x11.c
@@ -3,34 +3,60 @@
 #include "../common/getenv.h"
 #include "gtk_lock.h"
 #include "gui.h"
+#include <X11/XKBlib.h>
 #include <X11/Xlib.h>
+#include <X11/extensions/XTest.h>
 #include <assert.h>
+#include <errno.h>
 #include <pthread.h>
 #include <stddef.h>
 #include <string.h>
 
-static void send_char(Display *display, Window window, char c) {
+typedef enum { KEYUP = False, KEYDOWN = True } keypress_t;
+
+static int send_shift(Display *display, keypress_t keypress) {
+
+  XModifierKeymap *modifiers = XGetModifierMapping(display);
+  if (modifiers == NULL)
+    return ENOMEM;
+
+  XTestFakeKeyEvent(display, modifiers->modifiermap[ShiftMapIndex], keypress,
+                    CurrentTime);
+  XSync(display, False);
+
+  XFreeModifiermap(modifiers);
+
+  return 0;
+}
+
+static int send_char(Display *display, char c) {
 
   assert(supported_upper(c) || supported_lower(c));
 
-  XKeyEvent e = {
-      .display = display,
-      .window = window,
-      .root = RootWindow(display, DefaultScreen(display)),
-      .subwindow = None,
-      .time = CurrentTime,
-      .x = 1,
-      .y = 1,
-      .x_root = 1,
-      .y_root = 1,
-      .same_screen = True,
-      .type = KeyPress,
-      .state = supported_upper(c) ? ShiftMask : 0,
-      .keycode = XKeysymToKeycode(display, c),
-  };
-  XSendEvent(display, window, True, KeyPressMask, (XEvent *)&e);
-  e.type = KeyRelease;
-  XSendEvent(display, window, True, KeyReleaseMask, (XEvent *)&e);
+  // optionally press Shift
+  if (supported_upper(c)) {
+    int r = send_shift(display, KEYDOWN);
+    if (r != 0)
+      return r;
+  }
+
+  // press the key
+  KeyCode code = XKeysymToKeycode(display, c);
+  XTestFakeKeyEvent(display, code, True, CurrentTime);
+  XSync(display, False);
+
+  // depress the key
+  XTestFakeKeyEvent(display, code, False, CurrentTime);
+  XSync(display, False);
+
+  // optionally depress Shift
+  if (supported_upper(c)) {
+    int r = send_shift(display, KEYUP);
+    if (r != 0)
+      return r;
+  }
+
+  return 0;
 }
 
 int send_text(const char *text) {
@@ -56,25 +82,16 @@ int send_text(const char *text) {
     return -1;
   }
 
-  // find the active window
-  Window win;
-  int state;
-  XGetInputFocus(d, &win, &state);
-  if (win == None) {
-    XCloseDisplay(d);
-    {
-      int err __attribute__((unused)) = pthread_mutex_unlock(&gtk_lock);
-      assert(err == 0);
-    }
-    show_error("no window focused");
-    return -1;
-  }
+  int rc = 0;
 
   for (size_t i = 0; i < strlen(text); i++) {
     assert(supported_upper(text[i]) || supported_lower(text[i]));
-    send_char(d, win, text[i]);
+    rc = send_char(d, text[i]);
+    if (rc != 0)
+      goto done;
   }
 
+done:
   XCloseDisplay(d);
 
   {
@@ -82,5 +99,10 @@ int send_text(const char *text) {
     assert(err == 0);
   }
 
-  return 0;
+  if (rc != 0) {
+    assert(rc == ENOMEM);
+    show_error("failed to type text: out of memory");
+  }
+
+  return rc;
 }


### PR DESCRIPTION
Somehow the previous code was unable to type into Firefox under Gnome on Fedora.
All indicators pointed to success, but the text simply would not show up. I
could not reproduce this in any other program than Firefox, but there also seems
to be nothing special about Firefox itself.

I cross-referenced `xdotool` which _can_ type into Firefox under these
conditions and discovered it uses two completely different code paths:

  1. Something resembling the previous logic we had here but with a lot more
     complexity when typing into an arbitrary window; or

  2. A simplified code path using XTest when typing into the active window.

I still do not fully understand the difference, but as we only need to ever type
into the active window I switched to using the XTest method and it just works.

Github: fixes #25 “pw-gui cannot type into Firefox on Fedora 34”