### PR TITLE
CI: remove manual test target specification

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ task:
       freebsd_instance:
         image_family: freebsd-14-0-snap
       install_script: pkg upgrade -y && pkg install -y base64 cmake cunit json-c openssl pkgconf vim && sudo python3 -m ensurepip && sudo python3 -m pip install pexpect && mkdir scrypt-build && cd scrypt-build && curl https://www.tarsnap.com/scrypt/scrypt-1.3.0.tgz -o scrypt-1.3.0.tgz && tar xf scrypt-1.3.0.tgz && cd scrypt-1.3.0 && ./configure --enable-libscrypt-kdf && make && sudo make install && cd ../..
-      test_script: uname -sr && python3 --version && mkdir build && cd build && cmake -DENABLE_GUI=OFF .. && cmake --build . -- pw-cli pw-gui-test-stub passwand-tests && cmake --build . -- check && sudo cmake --build . -- install
+      test_script: uname -sr && python3 --version && mkdir build && cd build && cmake -DENABLE_GUI=OFF .. && cmake --build . && cmake --build . -- check && sudo cmake --build . -- install
 
     - name: Linux, GCC, no GTK
       container:
@@ -21,7 +21,7 @@ task:
         LC_ALL: C
         UBSAN_OPTIONS: print_stacktrace=1
       install_script: apt-get update -y && apt-get install --no-install-recommends -y cmake libcunit1-dev libjson-c-dev libscrypt-kdf1 libscrypt-kdf-dev man-db python3-pexpect xxd
-      test_script: uname -sr && python3 --version && mkdir build && cd build && cmake -DENABLE_GUI=OFF .. && cmake --build . -- pw-cli pw-gui-test-stub passwand-tests && cmake --build . -- check && cmake --build . -- install
+      test_script: uname -sr && python3 --version && mkdir build && cd build && cmake -DENABLE_GUI=OFF .. && cmake --build . && cmake --build . -- check && cmake --build . -- install
 
     - name: Linux, GCC, GTK 2
       container:
@@ -34,7 +34,7 @@ task:
         LC_ALL: C
         UBSAN_OPTIONS: print_stacktrace=1
       install_script: apt-get update -y && apt-get install --no-install-recommends -y cmake libcunit1-dev libgtk2.0-dev libjson-c-dev libscrypt-kdf1 libscrypt-kdf-dev libxtst-dev man-db python3-pexpect xxd
-      test_script: uname -sr && python3 --version && mkdir build && cd build && cmake .. && cmake --build . -- pw-cli pw-gui-test-stub pw-gui passwand-tests test-type && cmake --build . -- check && cmake --build . -- install
+      test_script: uname -sr && python3 --version && mkdir build && cd build && cmake .. && cmake --build . && cmake --build . -- check && cmake --build . -- install
 
     - name: Linux, GCC, GTK 3
       container:
@@ -47,7 +47,7 @@ task:
         LC_ALL: C
         UBSAN_OPTIONS: print_stacktrace=1
       install_script: apt-get update -y && apt-get install --no-install-recommends -y cmake libcunit1-dev libgtk-3-dev libjson-c-dev libscrypt-kdf1 libscrypt-kdf-dev libxtst-dev man-db python3-pexpect xxd
-      test_script: uname -sr && python3 --version && mkdir build && cd build && cmake .. && cmake --build . -- pw-cli pw-gui-test-stub pw-gui passwand-tests test-type && cmake --build . -- check && cmake --build . -- install
+      test_script: uname -sr && python3 --version && mkdir build && cd build && cmake .. && cmake --build . && cmake --build . -- check && cmake --build . -- install
 
     - name: macOS
       osx_instance:
@@ -57,7 +57,7 @@ task:
         LDFLAGS: -L/usr/local/opt/openssl/lib -L/usr/local/lib
         PKG_CONFIG_PATH: /usr/local/opt/openssl/lib/pkgconfig
       install_script: brew update && brew install cunit json-c openssl && sudo pip3 install pexpect && mkdir scrypt-build && cd scrypt-build && curl https://www.tarsnap.com/scrypt/scrypt-1.3.0.tgz -o scrypt-1.3.0.tgz && tar xf scrypt-1.3.0.tgz && cd scrypt-1.3.0 && ./configure --enable-libscrypt-kdf && make && sudo make install && cd ../..
-      test_script: uname -sr && python3 --version && mkdir build && cd build && cmake .. && cmake --build . -- pw-cli pw-gui-test-stub pw-gui passwand-tests test-type && cmake --build . -- check && sudo cmake --build . -- install
+      test_script: uname -sr && python3 --version && mkdir build && cd build && cmake .. && cmake --build . && cmake --build . -- check && sudo cmake --build . -- install
 
     - name: clang-format
       container:


### PR DESCRIPTION
Following 50980bb364d65d6e5370f3af2bf11d92ced8f2a9, there should be no need for
this.