### PR TITLE
fix: swap some 'posix_memalign' for 'aligned_alloc', avoiding UB

### DIFF
--- a/tests/test_encrypt.c
+++ b/tests/test_encrypt.c
@@ -75,11 +75,10 @@ TEST("AES128 reads at most 128 bits of a supplied key") {
   // reads more than 128 bits.
   int pagesize = sysconf(_SC_PAGESIZE);
   assert(pagesize >= 16 && "AES key does not fit in a page");
-  unsigned char *p;
-  int r = posix_memalign((void **)&p, pagesize, pagesize * 2);
-  ASSERT_EQ(r, 0);
+  unsigned char *p = aligned_alloc(pagesize, pagesize * 2);
+  ASSERT_NOT_NULL(p);
   // make the second page inaccessible
-  r = mprotect(p + pagesize, pagesize, PROT_NONE);
+  int r = mprotect(p + pagesize, pagesize, PROT_NONE);
   ASSERT_EQ(r, 0);
   // write a dummy key into the end of the first page
   unsigned char *key = p + pagesize - 16;
@@ -143,14 +142,13 @@ TEST("AES128 reads at least 128 bits of a supplied key") {
   // should allow us to detect if AES128 does not read to the end of the key.
   int pagesize = sysconf(_SC_PAGESIZE);
   assert(pagesize >= 16 && "AES key does not fit in a page");
-  unsigned char *p;
-  int r = posix_memalign((void **)&p, pagesize, pagesize * 2);
-  ASSERT_EQ(r, 0);
+  unsigned char *p = aligned_alloc(pagesize, pagesize * 2);
+  ASSERT_NOT_NULL(p);
   // write a dummy key into the end of the first page and first byte of second
   unsigned char *key = p + pagesize - 15;
   memset(key, 0, 16);
   // make the second page inaccessible
-  r = mprotect(p + pagesize, pagesize, PROT_NONE);
+  int r = mprotect(p + pagesize, pagesize, PROT_NONE);
   ASSERT_EQ(r, 0);
 
   // setup a context for encryption
@@ -213,11 +211,10 @@ TEST("AES128 reads at most 16 bytes of a supplied initialisation vector") {
   // reads more than 16 bytes.
   int pagesize = sysconf(_SC_PAGESIZE);
   assert(pagesize >= 16 && "AES IV does not fit in a page");
-  unsigned char *p;
-  int r = posix_memalign((void **)&p, pagesize, pagesize * 2);
-  ASSERT_EQ(r, 0);
+  unsigned char *p = aligned_alloc(pagesize, pagesize * 2);
+  ASSERT_NOT_NULL(p);
   // make the second page inaccessible
-  r = mprotect(p + pagesize, pagesize, PROT_NONE);
+  int r = mprotect(p + pagesize, pagesize, PROT_NONE);
   ASSERT_EQ(r, 0);
   // write a dummy IV into the end of the first page
   unsigned char *iv = p + pagesize - 16;
@@ -278,14 +275,13 @@ TEST("AES128 reads at least 16 bytes of a supplied initialisation vector") {
   // purpose of this is to detect if the AES algorithm reads less than 16 bytes.
   int pagesize = sysconf(_SC_PAGESIZE);
   assert(pagesize >= 16 && "AES IV does not fit in a page");
-  unsigned char *p;
-  int r = posix_memalign((void **)&p, pagesize, pagesize * 2);
-  ASSERT_EQ(r, 0);
+  unsigned char *p = aligned_alloc(pagesize, pagesize * 2);
+  ASSERT_NOT_NULL(p);
   // write a dummy IV into the end of the first page
   unsigned char *iv = p + pagesize - 15;
   memset(iv, 0, 16);
   // make the second page inaccessible
-  r = mprotect(p + pagesize, pagesize, PROT_NONE);
+  int r = mprotect(p + pagesize, pagesize, PROT_NONE);
   ASSERT_EQ(r, 0);
 
   // setup a context for encryption
@@ -346,11 +342,10 @@ TEST("AES256 reads at most 256 bits of a supplied key") {
   // reads more than 256 bits.
   int pagesize = sysconf(_SC_PAGESIZE);
   assert(pagesize >= 32 && "AES key does not fit in a page");
-  unsigned char *p;
-  int r = posix_memalign((void **)&p, pagesize, pagesize * 2);
-  ASSERT_EQ(r, 0);
+  unsigned char *p = aligned_alloc(pagesize, pagesize * 2);
+  ASSERT_NOT_NULL(p);
   // make the second page inaccessible
-  r = mprotect(p + pagesize, pagesize, PROT_NONE);
+  int r = mprotect(p + pagesize, pagesize, PROT_NONE);
   ASSERT_EQ(r, 0);
   // write a dummy key into the end of the first page
   unsigned char *key = p + pagesize - 32;
@@ -410,14 +405,13 @@ TEST("AES256 reads at least 256 bits of a supplied key") {
   // should allow us to detect if AES256 does not read to the end of the key.
   int pagesize = sysconf(_SC_PAGESIZE);
   assert(pagesize >= 32 && "AES key does not fit in a page");
-  unsigned char *p;
-  int r = posix_memalign((void **)&p, pagesize, pagesize * 2);
-  ASSERT_EQ(r, 0);
+  unsigned char *p = aligned_alloc(pagesize, pagesize * 2);
+  ASSERT_NOT_NULL(p);
   // write a dummy key into the end of the first page and first byte of second
   unsigned char *key = p + pagesize - 31;
   memset(key, 0, 32);
   // make the second page inaccessible
-  r = mprotect(p + pagesize, pagesize, PROT_NONE);
+  int r = mprotect(p + pagesize, pagesize, PROT_NONE);
   ASSERT_EQ(r, 0);
 
   // setup a context for encryption
@@ -480,11 +474,10 @@ TEST("AES256 reads at most 16 bytes of a supplied initialisation vector") {
   // reads more than 16 bytes.
   int pagesize = sysconf(_SC_PAGESIZE);
   assert(pagesize >= 16 && "AES IV does not fit in a page");
-  unsigned char *p;
-  int r = posix_memalign((void **)&p, pagesize, pagesize * 2);
-  ASSERT_EQ(r, 0);
+  unsigned char *p = aligned_alloc(pagesize, pagesize * 2);
+  ASSERT_NOT_NULL(p);
   // make the second page inaccessible
-  r = mprotect(p + pagesize, pagesize, PROT_NONE);
+  int r = mprotect(p + pagesize, pagesize, PROT_NONE);
   ASSERT_EQ(r, 0);
   // write a dummy IV into the end of the first page
   unsigned char *iv = p + pagesize - 16;
@@ -545,14 +538,13 @@ TEST("AES256 reads at least 16 bytes of a supplied initialisation vector") {
   // purpose of this is to detect if the AES algorithm reads less than 16 bytes.
   int pagesize = sysconf(_SC_PAGESIZE);
   assert(pagesize >= 16 && "AES IV does not fit in a page");
-  unsigned char *p;
-  int r = posix_memalign((void **)&p, pagesize, pagesize * 2);
-  ASSERT_EQ(r, 0);
+  unsigned char *p = aligned_alloc(pagesize, pagesize * 2);
+  ASSERT_NOT_NULL(p);
   // write a dummy IV into the end of the first page
   unsigned char *iv = p + pagesize - 15;
   memset(iv, 0, 16);
   // make the second page inaccessible
-  r = mprotect(p + pagesize, pagesize, PROT_NONE);
+  int r = mprotect(p + pagesize, pagesize, PROT_NONE);
   ASSERT_EQ(r, 0);
 
   // setup a context for encryption


### PR DESCRIPTION
Casting a `unsigned char *` to `void **` is Undefined Behaviour in these situations. The compiler noticed this during release builds:

```
    tests/test_encrypt.c: In function ‘test_61’:
    tests/test_encrypt.c:79:35: warning: dereferencing type-punned pointer might
      break strict-aliasing rules [-Wstrict-aliasing]
       79 |   int r = posix_memalign((void **)&p, pagesize, pagesize * 2);
          |                                   ^~
    …
    tests/test_encrypt.c:548:18: warning: ‘p’ may be used uninitialized
      [-Wmaybe-uninitialized]
      548 |   unsigned char *p;
          |                  ^
    …
```

This is an unfortunate sharp edge of `posix_memalign` as explained by the Muslc maintainer, Rich Felker, in a Stack Overflow answer:¹

```
  …this is a _classic anti-pattern_ in C, and one which should be burned with
  fire. It appears in:
  …
  2. Allocation functions that shun the standard C idiom of returning `void *` (which doesn't suffer from this issue because it involves a _value conversion_ instead of _type punning_), instead returning an error flag and storing the result via a pointer-to-pointer. … For (2), both cudaMalloc and posix_memalign are examples.

  In neither case does the interface inherently _require_ invalid usage, but it
  strongly encourages it, and admits correct usage only with an extra temporary
  object of type `void *` that defeats the purpose of the free-and-null-out
  functionality, and makes allocation awkward.
```

This is not the only instance of this pattern with `posix_memalign` in the code base. There are also other instances of UB that GCC spots.

¹ https://stackoverflow.com/questions/58809360/why-is-this-claimed-dereferencing-type-punned-pointer-warning-compiler-specific

Reported-by: GCC 14.2.1