### PR TITLE
fix mistaken out-of-memory detection when single threaded

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -467,7 +467,7 @@ int main(int argc, char **argv) {
   // allocate threads
   assert(options.jobs >= 1);
   threads = calloc(options.jobs - 1, sizeof(threads[0]));
-  if (threads == NULL) {
+  if (options.jobs > 1 && threads == NULL) {
     eprint("out of memory\n");
     goto done;
   }


### PR DESCRIPTION
It is legal for libc to return `NULL` from `calloc(0, …)`, as CodeChecker observes:

```
  [MEDIUM] cli/main.c:469:13: Call to 'calloc' has an allocation size of 0 bytes
    [optin.portability.UnixAPI]
    threads = calloc(options.jobs - 1, sizeof(threads[0]));
              ^
```

Reported-by: CodeChecker 6.26.2