### PR TITLE
CI: migrate FreeBSD job to Github Actions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,12 +4,6 @@ task:
   only_if: $CIRRUS_BRANCH == "main" || $CIRRUS_PR != ""
 
   matrix:
-    - name: FreeBSD
-      freebsd_instance:
-        image_family: freebsd-15-0-snap
-      install_script: pkg upgrade -y && pkg install -y base64 cmake json-c openssl pkgconf scrypt vim && sudo python3 -m ensurepip && sudo python3 -m pip install pexpect pytest
-      test_script: uname -sr && python3 --version && mkdir build && cd build && cmake -DENABLE_GUI=OFF .. && cmake --build . && cmake --build . -- check && sudo cmake --build . -- install
-
     - name: Linux, GCC, no GTK
       container:
         image: gcc:15.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Github Actions CI
+permissions: {}
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  freebsd15:
+    name: FreeBSD 15.0
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: vmactions/freebsd-vm@7ca82f79fe3078fecded6d3a2bff094995447bbd
+      with:
+        sync: no
+        release: "15.0"
+        usesh: true
+        run: |
+          set -e
+          set -o pipefail
+          set -u
+          set -x
+          uname -rms
+          pkg install -y base64 cmake git json-c openssl pkgconf python3 py311-pexpect py311-pytest scrypt vim
+          python3 --version
+          git clone --no-checkout -- ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} wd
+          cd wd
+          git fetch -- origin ${{ github.event.pull_request.head.sha }}
+          git checkout FETCH_HEAD
+          export CFLAGS="-Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined"
+          export UBSAN_OPTIONS=print_stacktrace=1
+          cmake -DENABLE_GUI=OFF -B build -S .
+          cmake --build build
+          cmake --build build --target check
+          cmake --install build


### PR DESCRIPTION
Cirrus CI is being shutdown:¹

  Cirrus CI will shut down effective Monday, June 1, 2026.

So we need to migrate to something else. The best option at present seems to be Github Actions. The Cirrus CI FreeBSD job no longer runs anyway because snaps are no longer supported, so it gets to be the first guinea pig. We take this opportunity to do a few extra things:
  • enable ASan, UBSan
  • switch to more modern CMake practices

¹ https://cirruslabs.org/